### PR TITLE
Use isinstance instead of type()

### DIFF
--- a/bizdays.py
+++ b/bizdays.py
@@ -243,11 +243,11 @@ class Date(object):
         d = d if d else date.today()
         if isstr(d):
             d = datetime.strptime(d, format).date()
-        elif type(d) is datetime:
+        elif isinstance(d, datetime):
             d = d.date()
-        elif type(d) is Date:
+        elif isinstance(d, Date):
             d = d.date
-        elif type(d) is date:
+        elif isinstance(d, date):
             pass
         else:
             raise ValueError()


### PR DESCRIPTION
Using `type()`: checks that the type of an argument is EXACTLY a given class, and will not match if we're using a subclass.

I'm using a project that uses freezegun for testing, so our date objects are actually subclasses of `datetime.date`, and not instances of _exactly_ that class.

This change does not break existing functionality, and should not break even under very odd scenarios which haven't been considered so far.